### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -5,38 +5,38 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-Event_Routine_Ptr		KEYWORD1
-Fifo_Set				KEYWORD1
-Fifo_Member				KEYWORD1
-Fifo_Member_Ptr			KEYWORD1
-Fifo_Set				KEYWORD1
-Generic_Member			KEYWORD1
-Generic_Member_Ptr		KEYWORD1
-Generic_Set				KEYWORD1
-Lifo_Member				KEYWORD1
-Lifo_Member_Ptr			KEYWORD1
-Lifo_Set				KEYWORD1
-Ranked_Member			KEYWORD1
-Ranked_Member_Ptr		KEYWORD1
-Ranked_Set				KEYWORD1
-Ranking_Type			KEYWORD1
-Time_File_Member		KEYWORD1
+Event_Routine_Ptr	KEYWORD1
+Fifo_Set	KEYWORD1
+Fifo_Member	KEYWORD1
+Fifo_Member_Ptr	KEYWORD1
+Fifo_Set	KEYWORD1
+Generic_Member	KEYWORD1
+Generic_Member_Ptr	KEYWORD1
+Generic_Set	KEYWORD1
+Lifo_Member	KEYWORD1
+Lifo_Member_Ptr	KEYWORD1
+Lifo_Set	KEYWORD1
+Ranked_Member	KEYWORD1
+Ranked_Member_Ptr	KEYWORD1
+Ranked_Set	KEYWORD1
+Ranking_Type	KEYWORD1
+Time_File_Member	KEYWORD1
 Time_File_Member_Ptr	KEYWORD1
-Time_File_Set			KEYWORD1
-Time_Type				KEYWORD1
-Time_File_Set			KEYWORD1
+Time_File_Set	KEYWORD1
+Time_Type	KEYWORD1
+Time_File_Set	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-Cancel					KEYWORD2
-Cause					KEYWORD2
-File					KEYWORD2
-File_Before				KEYWORD2
-File_First				KEYWORD2
-File_Last				KEYWORD2
-Remove					KEYWORD2
-Remove_First			KEYWORD2
-Remove_Specific			KEYWORD2
+Cancel	KEYWORD2
+Cause	KEYWORD2
+File	KEYWORD2
+File_Before	KEYWORD2
+File_First	KEYWORD2
+File_Last	KEYWORD2
+Remove	KEYWORD2
+Remove_First	KEYWORD2
+Remove_Specific	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords